### PR TITLE
serialize NA values to null, not to charactrer "NA"

### DIFF
--- a/R/gwalkr.R
+++ b/R/gwalkr.R
@@ -50,7 +50,7 @@ gwalkr <- function(data, lang = "en", dark = "light", columnSpecs = list(), visC
     gwalkr_kernel(data, lang, dark, rawFields, visConfig, toolbarExclude)
   } else {
     x = list(
-      dataSource = toJSON(data),
+      dataSource = toJSON(data, na='null'),
       rawFields = rawFields,
       i18nLang = lang,
       visSpec = visConfig,


### PR DESCRIPTION
jsonlite::toJSON by default converts NA_real_ and NA_integer_ to "NA", which causes an issue https://github.com/Kanaries/GWalkR/issues/42 