### PR TITLE
Add Shiny example for exporting visConfig

### DIFF
--- a/R/visconfig.R
+++ b/R/visconfig.R
@@ -8,6 +8,29 @@
 #' @param session The shiny session object.
 #'
 #' @return No return value. The result will be available on the client side.
+#'
+#' @examples
+#' # A simple Shiny app that prints the exported config
+#' library(shiny)
+#' library(GWalkR)
+#' data(mtcars)
+#'
+#' ui <- fluidPage(
+#'   gwalkrOutput("gw"),
+#'   actionButton("save", "Save Viz"),
+#'   verbatimTextOutput("config")
+#' )
+#'
+#' server <- function(input, output, session) {
+#'   output$gw <- renderGwalkr(gwalkr(mtcars))
+#'
+#'   observeEvent(input$save, request_vis_config("gw"))
+#'
+#'   output$config <- renderText({ input$gw_visConfig })
+#' }
+#'
+#' if (interactive()) shinyApp(ui, server)
+#'
 #' @export
 request_vis_config <- function(id, session = shiny::getDefaultReactiveDomain()) {
   if (is.null(session)) {

--- a/README.md
+++ b/README.md
@@ -64,6 +64,32 @@ Showcase your data insights with editable and explorable charts on a webpage ([e
 
 <img width="700" alt="image" src="https://github.com/bruceyyu/GWalkR/assets/33870780/4798367c-0dd4-4ad3-b25b-7ea48b79205a">
 
+### Save and restore visualizations in Shiny
+
+Use `request_vis_config()` to programmatically export the current visualization configuration from a `gwalkr` widget. The snippet below prints the JSON after clicking **Save Viz**.
+
+```R
+library(shiny)
+library(GWalkR)
+data(mtcars)
+
+ui <- fluidPage(
+  gwalkrOutput("gw"),
+  actionButton("save", "Save Viz"),
+  verbatimTextOutput("config")
+)
+
+server <- function(input, output, session) {
+  output$gw <- renderGwalkr(gwalkr(mtcars))
+  observeEvent(input$save, request_vis_config("gw"))
+  output$config <- renderText({ input$gw_visConfig })
+}
+
+if (interactive()) shinyApp(ui, server)
+```
+
+See `inst/examples/export_vis_config/app.R` for a complete example.
+
 ## Development
 We encourage developers from the amazing open-source community to help improve this R package! 
 

--- a/inst/examples/export_vis_config/app.R
+++ b/inst/examples/export_vis_config/app.R
@@ -1,0 +1,23 @@
+library(shiny)
+library(GWalkR)
+
+data(mtcars)
+
+ui <- fluidPage(
+  titlePanel("Export GWalkR Configuration"),
+  gwalkrOutput("gw", height = "600px"),
+  actionButton("save", "Save Viz"),
+  verbatimTextOutput("config")
+)
+
+server <- function(input, output, session) {
+  output$gw <- renderGwalkr(gwalkr(mtcars))
+
+  observeEvent(input$save, request_vis_config("gw"))
+
+  output$config <- renderText({
+    input$gw_visConfig
+  })
+}
+
+shinyApp(ui, server)

--- a/man/request_vis_config.Rd
+++ b/man/request_vis_config.Rd
@@ -18,3 +18,23 @@ No return value. The result will be available on the client side via
 Send a message to the browser to export the current visualization configuration
 of a \code{gwalkr} widget.
 }
+
+\examples{
+library(shiny)
+library(GWalkR)
+data(mtcars)
+
+ui <- fluidPage(
+  gwalkrOutput("gw"),
+  actionButton("save", "Save Viz"),
+  verbatimTextOutput("config")
+)
+
+server <- function(input, output, session) {
+  output$gw <- renderGwalkr(gwalkr(mtcars))
+  observeEvent(input$save, request_vis_config("gw"))
+  output$config <- renderText({ input$gw_visConfig })
+}
+
+if (interactive()) shinyApp(ui, server)
+}


### PR DESCRIPTION
## Summary
- document how to programmatically export the current visConfig in a shiny app
- include an example shiny app under `inst/examples`
- update `request_vis_config` docs with a usage example

## Testing
- `R` command not found so package checks were skipped